### PR TITLE
Revert "feat: Allows Prefixing the library."

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -74,7 +74,6 @@ jobs:
         openssl: [ "dyn", "sta" ]
         libevent: [ "dyn", "sta" ]
         zlib: [ "dyn", "sta" ]
-        prefix: [ "yes", "no" ]
     needs: AutoDarwin
     steps:
       - name: Set up Go 1.x
@@ -93,7 +92,6 @@ jobs:
           OPENSSL_TYPE: ${{ matrix.openssl }}
           LIBEVENT_TYPE: ${{ matrix.libevent }}
           ZLIB_TYPE: ${{ matrix.zlib }}
-          PREFIX_GO_LIBTOR: ${{ matrix.prefix }}
         run: |
           if [ "$OPENSSL_TYPE" == "dyn" ] || [ "$LIBEVENT_TYPE" == "dyn" ] || [ "$ZLIB_TYPE" == "dyn" ]; then
             sudo apt update
@@ -101,7 +99,7 @@ jobs:
           fi
           tar xf go-libtor.tar
           cd go-libtor
-          go build -v -x -tags="$(if [ "$LIBEVENT_TYPE" == "sta" ]; then echo -n "staticLibevent"; fi),$(if [ "$OPENSSL_TYPE" == "sta" ]; then echo -n "staticOpenssl"; fi),$(if [ "$ZLIB_TYPE" == "sta" ]; then echo -n "staticZlib"; fi),$(if [ "$PREFIX_GO_LIBTOR" == "yes" ]; then echo -n "prefixGoLibtor"; fi)" .
+          go build -v -x -tags="$(if [ "$LIBEVENT_TYPE" == "sta" ]; then echo -n "staticLibevent"; fi),$(if [ "$OPENSSL_TYPE" == "sta" ]; then echo -n "staticOpenssl"; fi),$(if [ "$ZLIB_TYPE" == "sta" ]; then echo -n "staticZlib"; fi)" .
   TestMacosDynamic:
     runs-on: macos-latest
     needs: AutoDarwin
@@ -126,9 +124,6 @@ jobs:
   TestMacosStatic:
     runs-on: macos-latest
     needs: AutoDarwin
-    strategy:
-      matrix:
-        prefix: [ "yes", "no" ]
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -142,12 +137,10 @@ jobs:
           path: .
 
       - name: Building
-        env:
-          PREFIX_GO_LIBTOR: ${{ matrix.prefix }}
         run: |
           tar xf go-libtor.tar
           cd go-libtor
-          go build -v -x -tags="staticOpenssl,staticZlib,staticLibevent,$(if [ "$PREFIX_GO_LIBTOR" == "yes" ]; then echo -n "prefixGoLibtor"; fi)" .
+          go build -v -x -tags="staticOpenssl,staticZlib,staticLibevent" .
   TestIOS:
     runs-on: macos-latest
     needs: AutoDarwin

--- a/build/libtor_internal.go.in
+++ b/build/libtor_internal.go.in
@@ -4,10 +4,6 @@ package libtor
 // This file is a simplified clone from github.com/cretz/bine/process/embedded.
 
 /*
-#ifdef PREFIX_GO_LIBTOR
-# pragma extern_prefix GO_LIBTOR_
-#endif
-
 #include <stdlib.h>
 #include <tor_api.h>
 

--- a/build/libtor_preamble.go.in
+++ b/build/libtor_preamble.go.in
@@ -8,8 +8,6 @@ package libtor
 #cgo android,amd64 android,arm64               CFLAGS: -DARCH_ANDROID64
 #cgo android,386 android,arm                   CFLAGS: -DARCH_ANDROID32
 
-#cgo prefixGoLibtor CFLAGS: -DPREFIX_GO_LIBTOR
-
 #cgo !staticOpenssl  LDFLAGS: -lssl -lcrypto
 #cgo !staticZlib     LDFLAGS: -lz
 #cgo !staticLibevent LDFLAGS: -levent

--- a/build/wrap.go
+++ b/build/wrap.go
@@ -272,10 +272,6 @@ var zlibTemplate = `// go-libtor - Self-contained Tor from Go
 package libtor
 
 /*
-#ifdef PREFIX_GO_LIBTOR
-# pragma extern_prefix GO_LIBTOR_
-#endif
-
 #include <../zlib/{{.File}}.c>
 */
 import "C"
@@ -457,10 +453,6 @@ var libeventTemplate = `// go-libtor - Self-contained Tor from Go
 package libtor
 
 /*
-#ifdef PREFIX_GO_LIBTOR
-# pragma extern_prefix GO_LIBTOR_
-#endif
-
 #include <compat/sys/queue.h>
 #include <../{{.File}}.c>
 */
@@ -691,10 +683,6 @@ var opensslTemplate = `// go-libtor - Self-contained Tor from Go
 package libtor
 
 /*
-#ifdef PREFIX_GO_LIBTOR
-# pragma extern_prefix GO_LIBTOR_
-#endif
-
 #define DSO_NONE
 #define OPENSSLDIR "/usr/local/ssl"
 #define ENGINESDIR "/usr/local/lib/engines"
@@ -952,10 +940,6 @@ var torTemplate = `// go-libtor - Self-contained Tor from Go
 package libtor
 
 /*
-#ifdef PREFIX_GO_LIBTOR
-# pragma extern_prefix GO_LIBTOR_
-#endif
-
 #define BUILDDIR ""
 
 #include <../{{.File}}.c>


### PR DESCRIPTION
Reverts berty/go-libtor#14

In fact this is not a supported option on modern systems.